### PR TITLE
Properly recurse over multi-case conditionals that result in a nested tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/index.js
+++ b/index.js
@@ -33,6 +33,9 @@ function recurse(nodes, test) {
           memo = memo.concat(recurse([node], test));
         }
       }).filter(Boolean), test, memo));
+
+      // Recurse over node.els to detect nested conditional expressions
+      memo.push.apply(memo, recurse([node.els], test));
     }
 
     if (node.elsif) {
@@ -41,6 +44,9 @@ function recurse(nodes, test) {
           memo = memo.concat(recurse([node], test));
         }
       }).filter(Boolean), test, memo));
+
+      // Recurse over node.elsif to detect nested conditional expressions
+      memo.push.apply(memo, recurse([node.elsif], test));
     }
 
     memo.push.apply(memo, recurse(node.nodes, test, memo));

--- a/package.json
+++ b/package.json
@@ -4,5 +4,15 @@
   "description": "Visits Combyne nodes in the AST",
   "main": "index.js",
   "author": "Tim Branyen (@tbranyen)",
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "test": "mocha tests.js"
+  },
+  "devDependencies": {
+    "combyne": "^0.8.1",
+    "mocha": "^2.2.5"
+  },
+  "files": [
+    "index.js"
+  ]
 }

--- a/tests.js
+++ b/tests.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var assert = require('assert');
+var combyne = require('combyne');
+var visitCombyne = require('./index');
+
+describe('visit-combyne', function() {
+  var template;
+
+  describe('if-elseif conditionals', function() {
+    beforeEach(function() {
+      template = combyne('{%if case1%}1{%elsif case2%}2{%else%}3{%endif%}');
+    });
+
+    it('correctly recurses over all nodes in conditional chains', function() {
+      var visitedNodes = {};
+
+      // Count how many nodes of each type are visited
+      visitCombyne(template.tree.nodes, function(node) {
+        if ( ! visitedNodes[node.type] ) { visitedNodes[node.type] = 0; }
+        visitedNodes[node.type]++;
+      });
+
+      assert.equal(visitedNodes.ConditionalExpression, 3,
+        'finds three conditional nodes ("if", "elsif", "else")');
+      assert.equal(visitedNodes.Property, 2,
+        'finds two property nodes, "case1" and "case2"');
+      assert.equal(visitedNodes.Text, 3,
+        'finds three text nodes, "1", "2", "3"');
+    });
+  });
+});


### PR DESCRIPTION
As described in #1, `if() {} else if() {} else if() {}` structures in templates are not parsed correctly: the nodes of the first conditional segment are recursed over, but any subsequent conditional cases in the template are skipped (so in the JS pseudocode example above, only the nodes within that first `if() {}` block would be visited).

I am not familiar enough with the AST generated by Combyne to know if the nesting structure for conditionals is accurate, but this PR adds a test to demonstrate the failing case, and a patch to the library itself that should resolve the bug.
